### PR TITLE
APEX-123 Get Cardano validator/batcher informations from smart contract

### DIFF
--- a/contracts/interfaces/IBridgeContract.sol
+++ b/contracts/interfaces/IBridgeContract.sol
@@ -19,8 +19,16 @@ abstract contract IBridgeContract is IBridgeContractStructs {
         UTXOs calldata _initialUTXOs,
         string calldata _addressMultisig,
         string calldata _addressFeePayer,
-        string calldata _keyHashMultisig,
-        string calldata _keyHashFeePayer,
+        ValidatorAddressCardanoData[] calldata validatorData,
+        uint256 _tokenQuantity
+    ) external virtual;
+
+    function registerChainGovernance(
+        string calldata _chainId,
+        UTXOs calldata _initialUTXOs,
+        string calldata _addressMultisig,
+        string calldata _addressFeePayer,
+        ValidatorCardanoData calldata validatorData,
         uint256 _tokenQuantity
     ) external virtual;
 
@@ -44,6 +52,8 @@ abstract contract IBridgeContract is IBridgeContractStructs {
     function getConfirmedBatch(
         string calldata _destinationChain
     ) external view virtual returns (ConfirmedBatch memory batch);
+
+    function getValidatorsCardanoData(string calldata _chainId) external view virtual returns (ValidatorCardanoData[] memory validators);
 
     function getLastObservedBlock(string calldata _sourceChain) external view virtual returns (CardanoBlock memory cblock);
 

--- a/contracts/interfaces/IBridgeContractStructs.sol
+++ b/contracts/interfaces/IBridgeContractStructs.sol
@@ -133,8 +133,6 @@ interface IBridgeContractStructs {
         UTXOs utxos;
         string addressMultisig;
         string addressFeePayer;
-        string keyHashMultisig;
-        string keyHashFeePayer;
         uint256 tokenQuantity;
     }
 
@@ -151,11 +149,16 @@ interface IBridgeContractStructs {
         uint256 slot;
     }
 
+    struct ValidatorAddressCardanoData {
+        address addr;
+        ValidatorCardanoData data;
+    }
+
     struct ValidatorCardanoData {
         string keyHash;
         string keyHashFee;
-        bytes verifyingKey;
-        bytes verifyingKeyFee;
+        string verifyingKey;
+        string verifyingKeyFee;
     }
 
     error AlreadyConfirmed(string _claimTransactionHash);
@@ -171,6 +174,7 @@ interface IBridgeContractStructs {
     error NotSignedBatchManagerOrBridgeContract();
     error NotEnoughBridgingTokensAwailable(string _claimTransactionHash);
     error CanNotCreateBatchYet(string _blockchainID);
+    error InvalidData(string data);
     //TODO: remove when not needed anymore
     error RefundRequestClaimNotYetSupporter();
 


### PR DESCRIPTION
- Fix register chain functions (keyhashes/verifying keys must be preserved for each validator)
- `function getValidatorsCardanoData(string calldata _chainId) external view virtual returns (ValidatorCardanoData[] memory validators)`

Note:
For creating cardano transactions batchers need keyhashes for creating policy script. These keyhashes are already submitted to the chain via registerChain.