### PR TITLE
_submitClaimsBRC fix

### DIFF
--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -163,11 +163,11 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
 
             utxosc.addNewBridgingUTXO(_claim.sourceChainID, _claim.outputUTXO);
 
-            _setConfirmedTransactions(_claim);
+            uint256 confirmedTxCount = getBatchingTxsCount(_claim.destinationChainID);
 
+            _setConfirmedTransactions(_claim);
             claimsHelper.setClaimConfirmed(_claim.destinationChainID, _claim.observedTransactionHash);
 
-            uint256 confirmedTxCount = getBatchingTxsCount(_claim.destinationChainID);
             if (
                 (claimsHelper.currentBatchBlock(_claim.destinationChainID) == -1) && // there is no batch in progress
                 (confirmedTxCount == 0) && // check if there is no other confirmed transactions


### PR DESCRIPTION
` _setConfirmedTransactions(_claim);` should be called after 
`uint256 confirmedTxCount = getBatchingTxsCount(_claim.destinationChainID);`

`_setConfirmedTransactions` updates `lastConfirmedTxNonce` with
`uint256 nextNonce = ++lastConfirmedTxNonce[_claim.destinationChainID];`

and then if `confirmedTxCount` is calculated after, that new transaction will be always counted in final number. And we do not want that, we want state before new confirmed claim entered