### PR TITLE
Create contract verification files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ npx hardhat test
 REPORT_GAS=true npx hardhat test
 npx hardhat node
 ```
+
+Compile smart contracts
+
+```shell
+npx hardhat compile
+```
+
+Create the files that will be used to verify smart contracts on Blockscout
+
+```shell
+node contractVerification.js
+```

--- a/contractVerification.js
+++ b/contractVerification.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const encoding = 'utf-8'
+const jsonIndent = 4
+const contractsPath = path.join(__dirname, 'contracts')
+const artifactsPath = path.join(__dirname, 'artifacts');
+const buildInfoPath = path.join(artifactsPath, 'build-info');
+
+const contractsFiles = fs.readdirSync(contractsPath).filter(file => file.endsWith('.sol'))
+const buildInfoJsonPath = path.join(buildInfoPath, fs.readdirSync(buildInfoPath).filter(file => file.endsWith('.json'))[0]);
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, encoding));
+}
+
+function writeJson(data, filePath) {
+    fs.writeFileSync(`${filePath}_verification.json`, JSON.stringify(data, null, jsonIndent), encoding);
+}
+
+function getSources() {
+    return readJson(buildInfoJsonPath).input.sources;
+}
+
+function getContracts() {
+    return readJson(buildInfoJsonPath).output.contracts;
+}
+
+function createVerificationFiles() {
+    const sources = getSources();
+    const contracts = getContracts();
+    
+    Object.keys(contracts).forEach((key) => {
+        const contractName = Object.keys(contracts[key])[0];
+        
+        if (contractsFiles.includes(`${contractName}.sol`)) {
+            const metadata = JSON.parse(contracts[key][contractName].metadata);
+
+            Object.keys(metadata.sources).forEach((contractPath) => {
+                const contents = metadata.sources[contractPath];
+                delete contents.urls;
+                contents.content = sources[contractPath].content;
+            });
+
+            writeJson(metadata, path.join(artifactsPath, 'contracts', `${contractName}.sol`, contractName));
+        }
+    });
+}
+
+createVerificationFiles();

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.24",
     settings: {
+      evmVersion: "paris",
       optimizer: {
         enabled: true,
         runs: 1000,


### PR DESCRIPTION
Since the files generated after compilation are not in a valid format for use with Blockscout, we need to create new ones using the [Solidity Compiler Input Description](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) rules.