### PR TITLE
APEX-343 BatchExecutionInfo event should be emitted whenever BatchExecutedClaim or BatchExecutionFailedClaim is submitted 

### DIFF
--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -287,8 +287,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
     ) private {
         TxDataInfo[] memory _txHashes = new TxDataInfo[](_lastTxNounce - _firstTxNonce + 1);
         for (uint64 i = _firstTxNonce; i <= _lastTxNounce; i++) {
-            uint64 idx = i - _firstTxNonce;
-            _txHashes[idx] = TxDataInfo(
+            _txHashes[i - _firstTxNonce] = TxDataInfo(
                 confirmedTransactions[_chainId][i].sourceChainId,
                 confirmedTransactions[_chainId][i].observedTransactionHash
             );

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -95,7 +95,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
                 revert ChainIsNotRegistered(_claim.chainId);
             }
 
-            _submitClaimsBEC(_claim, i, _caller);
+            _submitClaimsBEC(_claim, _caller);
         }
 
         uint256 batchExecutionFailedClaimsLength = _claims.batchExecutionFailedClaims.length;
@@ -105,7 +105,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
                 revert ChainIsNotRegistered(_claim.chainId);
             }
 
-            _submitClaimsBEFC(_claim, i, _caller);
+            _submitClaimsBEFC(_claim, _caller);
         }
 
         uint256 refundRequestClaimsLength = _claims.refundRequestClaims.length;
@@ -168,7 +168,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
         }
     }
 
-    function _submitClaimsBEC(BatchExecutedClaim calldata _claim, uint idx, address _caller) internal {
+    function _submitClaimsBEC(BatchExecutedClaim calldata _claim, address _caller) internal {
         bytes32 claimHash = keccak256(abi.encode("BEC", _claim));
         bool _quorumReached = claimsHelper.setVotedOnlyIfNeeded(
             _caller,
@@ -185,7 +185,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
         uint64 _firstTxNounce = confirmedSignedBatch.firstTxNonceId;
         uint64 _lastTxNounce = confirmedSignedBatch.lastTxNonceId;
 
-        _emitBatchExecutionInfo(batchId, chainId, idx, false, _firstTxNounce, _lastTxNounce);
+        _emitBatchExecutionInfo(batchId, chainId, false, _firstTxNounce, _lastTxNounce);
 
         if (_quorumReached) {
             claimsHelper.resetCurrentBatchBlock(chainId);
@@ -195,7 +195,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
         }
     }
 
-    function _submitClaimsBEFC(BatchExecutionFailedClaim calldata _claim, uint idx, address _caller) internal {
+    function _submitClaimsBEFC(BatchExecutionFailedClaim calldata _claim, address _caller) internal {
         bytes32 claimHash = keccak256(abi.encode("BEFC", _claim));
         bool _quorumReached = claimsHelper.setVotedOnlyIfNeeded(
             _caller,
@@ -212,7 +212,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
         uint64 _firstTxNounce = confirmedSignedBatch.firstTxNonceId;
         uint64 _lastTxNounce = confirmedSignedBatch.lastTxNonceId;
 
-        _emitBatchExecutionInfo(batchId, chainId, idx, true, _firstTxNounce, _lastTxNounce);
+        _emitBatchExecutionInfo(batchId, chainId, true, _firstTxNounce, _lastTxNounce);
 
         if (_quorumReached) {
             claimsHelper.resetCurrentBatchBlock(chainId);
@@ -280,7 +280,6 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
     function _emitBatchExecutionInfo(
         uint64 _batchID,
         uint8 _chainId,
-        uint256 _claimIdx,
         bool _isFailedClaim,
         uint64 _firstTxNonce,
         uint64 _lastTxNounce
@@ -293,7 +292,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
             );
         }
 
-        emit BatchExecutionInfo(_batchID, _chainId, _claimIdx, _isFailedClaim, _txHashes);
+        emit BatchExecutionInfo(_batchID, _chainId, _isFailedClaim, _txHashes);
     }
 
     function setVoted(address _voter, bytes32 _hash) external onlyBridge returns (uint256) {

--- a/contracts/interfaces/IBridgeStructs.sol
+++ b/contracts/interfaces/IBridgeStructs.sol
@@ -160,7 +160,6 @@ interface IBridgeStructs {
     event BatchExecutionInfo(
         uint64 _batchID,
         uint8 _chainId,
-        uint256 _claimIdx,
         bool _isFailedClaim,
         TxDataInfo[] _txHashes
     );

--- a/contracts/interfaces/IBridgeStructs.sol
+++ b/contracts/interfaces/IBridgeStructs.sol
@@ -131,6 +131,11 @@ interface IBridgeStructs {
         uint256[4] key;
     }
 
+    struct TxDataInfo {
+        uint8 sourceChainId;
+        bytes32 observedTransactionHash;
+    }
+
     error AlreadyConfirmed(bytes32 _claimTransactionHash);
     error AlreadyProposed(uint8 _claimTransactionHash);
     error ChainAlreadyRegistered(uint8 _chainId);
@@ -142,7 +147,7 @@ interface IBridgeStructs {
     error NotSignedBatchesOrBridge();
     error NotSignedBatchesOrClaims();
     error NotEnoughBridgingTokensAvailable(bytes32 _claimTransactionHash);
-    error CanNotCreateBatchYet(uint8 _blockchainId);
+    error CanNotCreateBatchYet(uint8 _chainId);
     error InvalidData(string data);
     error ChainIsNotRegistered(uint8 _chainId);
     error WrongBatchNonce(uint8 _chainId, uint64 _nonce);
@@ -152,4 +157,11 @@ interface IBridgeStructs {
     event newChainRegistered(uint8 indexed _chainId);
     event NotEnoughFunds(string claimeType, uint256 index, uint256 availableAmount);
     event InsufficientFunds(uint256 availableAmount, uint256 withdrawalAmount);
+    event BatchExecutionInfo(
+        uint64 _batchID,
+        uint8 _chainId,
+        uint256 _claimIdx,
+        bool _isFailedClaim,
+        TxDataInfo[] _txHashes
+    );
 }

--- a/test/SubmitClaims.test.ts
+++ b/test/SubmitClaims.test.ts
@@ -304,7 +304,7 @@ describe("Submit Claims", function () {
       const batchExecutedClaim = validatorClaimsBEC.batchExecutedClaims[0];
       await expect(bridge.connect(validators[0]).submitClaims(validatorClaimsBEC))
         .to.emit(claims, "BatchExecutionInfo")
-        .withArgs(batchExecutedClaim.batchNonceId, batchExecutedClaim.chainId, 0, false, [
+        .withArgs(batchExecutedClaim.batchNonceId, batchExecutedClaim.chainId, false, [
           [validatorClaimsBRC.bridgingRequestClaims[0].sourceChainId, validatorClaimsBRC.bridgingRequestClaims[0].observedTransactionHash]
         ]);
     });
@@ -516,7 +516,7 @@ describe("Submit Claims", function () {
       const batchExecutionFailedClaim = validatorClaimsBEFC.batchExecutionFailedClaims[0];
       await expect(bridge.connect(validators[0]).submitClaims(validatorClaimsBEFC))
         .to.emit(claims, "BatchExecutionInfo")
-        .withArgs(batchExecutionFailedClaim.batchNonceId, batchExecutionFailedClaim.chainId, 0, true, [
+        .withArgs(batchExecutionFailedClaim.batchNonceId, batchExecutionFailedClaim.chainId, true, [
           [validatorClaimsBRC.bridgingRequestClaims[0].sourceChainId, validatorClaimsBRC.bridgingRequestClaims[0].observedTransactionHash]
         ]);
     });


### PR DESCRIPTION
```
    event BatchExecutionInfo(
        uint64 _batchID,
        uint8 _chainId,
        bool _isFailedClaim,
        TxDataInfo[] _txHashes
    );
   ``` 
   ```
    struct TxDataInfo {
        uint8 sourceChainId;
        bytes32 observedTransactionHash;
    }
   ```
   
`claimIdx` is index of a claim

`isFailedClaim bool` just specified the type of claim