### PR TITLE
audit: APEX-448 Flag _isIncrease is not checked when comparing the available quantity

### DIFF
--- a/contracts/Admin.sol
+++ b/contracts/Admin.sol
@@ -33,7 +33,7 @@ contract Admin is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrade
 
     function updateChainTokenQuantity(uint8 _chainId, bool _isIncrease, uint256 _quantity) external onlyFundAdmin {
         if (!claims.isChainRegistered(_chainId)) revert ChainIsNotRegistered(_chainId);
-        if (claims.chainTokenQuantity(_chainId) < _quantity)
+        if (!_isIncrease && claims.chainTokenQuantity(_chainId) < _quantity)
             revert NegativeChainTokenAmount(claims.chainTokenQuantity(_chainId), _quantity);
 
         claims.updateChainTokenQuantity(_chainId, _isIncrease, _quantity);

--- a/test/Admin.test.ts
+++ b/test/Admin.test.ts
@@ -40,6 +40,14 @@ describe("Admin Functions", function () {
       await admin.updateChainTokenQuantity(chain1.id, true, 100);
       expect(await claims.chainTokenQuantity(chain1.id)).to.equal(200);
     });
+    it("Should increase chainTokenQuantity after calling updateChainTokenQuantity with a value higher than the current one", async function () {
+      const { admin, bridge, claims, chain1, validatorsCardanoData } = await loadFixture(deployBridgeFixture);
+      await bridge.registerChain(chain1, 100, validatorsCardanoData);
+
+      expect(await claims.chainTokenQuantity(chain1.id)).to.equal(100);
+      await admin.updateChainTokenQuantity(chain1.id, true, 200);
+      expect(await claims.chainTokenQuantity(chain1.id)).to.equal(300);
+    });
     it("Should emit event after increaseint chain token quantity with updateChainTokenQuantity", async function () {
       const { admin, bridge, claims, chain1, validatorsCardanoData } = await loadFixture(deployBridgeFixture);
       await bridge.registerChain(chain1, 100, validatorsCardanoData);
@@ -58,10 +66,11 @@ describe("Admin Functions", function () {
       );
     });
     it("Should decrease chainTokenQuantity by required amount", async function () {
-      const { admin, bridge, chain1, validatorsCardanoData } = await loadFixture(deployBridgeFixture);
+      const { admin, bridge, claims, chain1, validatorsCardanoData } = await loadFixture(deployBridgeFixture);
       await bridge.registerChain(chain1, 100, validatorsCardanoData);
 
       await admin.updateChainTokenQuantity(chain1.id, false, 50);
+      expect(await claims.chainTokenQuantity(chain1.id)).to.equal(50);
     });
     it("Should emit event after decreasing chain token quantity with updateChainTokenQuantity", async function () {
       const { bridge, admin, chain1, validatorsCardanoData } = await loadFixture(deployBridgeFixture);


### PR DESCRIPTION
Component: Claims.sol

Reference: [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/66571fec0681e512323caa23ad321227f6b31e6a/contracts/Admin.sol#L36)

Category: Bug



The passed argument `_isIncrease` is not checked when evaluating if the chain has enough tokens in supply, causing the `NegativeChainTokenAmount` error even when adding tokens. In cases when the chain supply drops to 0, it may become impossible to update the quantity.