### PR TITLE
audit: APEX-454 Two loops can be merged into one + APEX-455 Multiple access to storage variable `validatorsCount` + APEX-456 Unused private variable `validatorsAddresses` + APEX 465 Getters should revert with an error when accessing missing values

### DIFF
--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -393,7 +393,12 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
     }
 
     function getChainTokenQuantity(uint8 _chainId) external view returns (uint256) {
-        return chainTokenQuantity[_chainId];
+        uint256 tokenQuantity = chainTokenQuantity[_chainId];
+
+        if (tokenQuantity == 0) {
+            revert("Can't find chain token quantity");
+        }
+        return tokenQuantity;
     }
 
     function updateChainTokenQuantity(

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -393,12 +393,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
     }
 
     function getChainTokenQuantity(uint8 _chainId) external view returns (uint256) {
-        uint256 tokenQuantity = chainTokenQuantity[_chainId];
-
-        if (tokenQuantity == 0) {
-            revert("Can't find chain token quantity");
-        }
-        return tokenQuantity;
+        return chainTokenQuantity[_chainId];
     }
 
     function updateChainTokenQuantity(

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -49,6 +49,8 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
     }
 
     function getValidatorIndex(address _addr) public view returns (uint8) {
+        uint8 index = addressValidatorIndex[_addr];
+        if (index == 0) revert NotValidator();
         return addressValidatorIndex[_addr];
     }
 

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -112,7 +112,8 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         uint8 _chainId,
         ValidatorAddressChainData[] calldata _chainDatas
     ) external onlyBridge {
-        if (validatorsCount != _chainDatas.length) {
+        uint8 validatorsCnt = validatorsCount;
+        if (validatorsCnt != _chainDatas.length) {
             revert InvalidData("validators count");
         }
 
@@ -120,9 +121,9 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         delete chainData[_chainId];
 
         // set validator chain data for each validator
-        for (uint i; i < validatorsCount; i++) {
+        for (uint i; i < validatorsCnt; i++) {
             chainData[_chainId].push();
-            
+
             ValidatorAddressChainData calldata dt = _chainDatas[i];
             uint8 indx = addressValidatorIndex[dt.addr];
             if (indx == 0) {

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -19,8 +19,6 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
 
     // BlockchainId -> ValidatorChainData[]
     mapping(uint8 => ValidatorChainData[]) private chainData;
-    // current validators set bridge addresses
-    address[] private validatorsAddresses;
     // validator address index(+1) in chainData mapping
     mapping(address => uint8) private addressValidatorIndex;
 
@@ -36,7 +34,6 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         upgradeAdmin = _upgradeAdmin;
         for (uint8 i; i < _validators.length; i++) {
             addressValidatorIndex[_validators[i]] = i + 1;
-            validatorsAddresses.push(_validators[i]);
         }
         validatorsCount = uint8(_validators.length);
     }

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -49,11 +49,7 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
     }
 
     function getValidatorIndex(address _addr) public view returns (uint8) {
-        uint8 index = addressValidatorIndex[_addr];
-        if (index == 0) {
-            revert("Validator does not exist");
-        }
-        return index;
+        return addressValidatorIndex[_addr];
     }
 
     function isSignatureValid(

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -118,12 +118,11 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
 
         // recreate array with n elements
         delete chainData[_chainId];
-        for (uint i; i < validatorsCount; i++) {
-            chainData[_chainId].push();
-        }
 
         // set validator chain data for each validator
         for (uint i; i < validatorsCount; i++) {
+            chainData[_chainId].push();
+            
             ValidatorAddressChainData calldata dt = _chainDatas[i];
             uint8 indx = addressValidatorIndex[dt.addr];
             if (indx == 0) {

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -49,7 +49,11 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
     }
 
     function getValidatorIndex(address _addr) public view returns (uint8) {
-        return addressValidatorIndex[_addr];
+        uint8 index = addressValidatorIndex[_addr];
+        if (index == 0) {
+            revert("Validator does not exist");
+        }
+        return index;
     }
 
     function isSignatureValid(


### PR DESCRIPTION
Resolved findings:
- APEX-454 Two loops can be merged into one
- APEX-455 Multiple access to storage variable `validatorsCount`
- APEX-456 Unused private variable `validatorsAddresses`
- APEX 465 Getters should revert with an error when accessing missing values