### PR TITLE
audit: APEX-455 Multiple access to storage variable validatorsCount

### DIFF
--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -112,7 +112,8 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         uint8 _chainId,
         ValidatorAddressChainData[] calldata _chainDatas
     ) external onlyBridge {
-        if (validatorsCount != _chainDatas.length) {
+        uint8 validatorsCnt = validatorsCount;
+        if (validatorsCnt != _chainDatas.length) {
             revert InvalidData("validators count");
         }
 
@@ -123,7 +124,7 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         }
 
         // set validator chain data for each validator
-        for (uint i; i < validatorsCount; i++) {
+        for (uint i; i < validatorsCnt; i++) {
             ValidatorAddressChainData calldata dt = _chainDatas[i];
             uint8 indx = addressValidatorIndex[dt.addr];
             if (indx == 0) {


### PR DESCRIPTION
Reference: [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/66571fec0681e512323caa23ad321227f6b31e6a/contracts/Validators.sol#L121)

Category: Performance

Multiple access to the storage variable `validatorsCount` may be fixed by storing the value in a local variable.