### PR TITLE
audit: APEX 465 Getters should revert with an error when accessing missing values

### DIFF
--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -54,7 +54,7 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
     function getValidatorIndex(address _addr) public view returns (uint8) {
         uint8 index = addressValidatorIndex[_addr];
         if (index == 0) revert NotValidator();
-        return addressValidatorIndex[_addr];
+        return index;
     }
 
     function isSignatureValid(

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -118,12 +118,11 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
 
         // recreate array with n elements
         delete chainData[_chainId];
-        for (uint i; i < validatorsCount; i++) {
-            chainData[_chainId].push();
-        }
 
         // set validator chain data for each validator
         for (uint i; i < validatorsCount; i++) {
+            chainData[_chainId].push();
+            
             ValidatorAddressChainData calldata dt = _chainDatas[i];
             uint8 indx = addressValidatorIndex[dt.addr];
             if (indx == 0) {

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -112,14 +112,14 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
         uint8 _chainId,
         ValidatorAddressChainData[] calldata _chainDatas
     ) external onlyBridge {
-        if (validatorsCount != _chainDatas.length) {
+        uint8 validatorsCnt = validatorsCount;
+        if (validatorsCnt != _chainDatas.length) {
             revert InvalidData("validators count");
         }
 
         // recreate array with n elements
         delete chainData[_chainId];
-
-        // set validator chain data for each validator
+        
         for (uint i; i < validatorsCount; i++) {
             chainData[_chainId].push();
             

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -52,6 +52,8 @@ contract Validators is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUp
     }
 
     function getValidatorIndex(address _addr) public view returns (uint8) {
+        uint8 index = addressValidatorIndex[_addr];
+        if (index == 0) revert NotValidator();
         return addressValidatorIndex[_addr];
     }
 


### PR DESCRIPTION
Reference: [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/427a2b6fda17aac51544564a527a54eebcaf96b3/contracts/Validators.sol#L54), [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/427a2b6fda17aac51544564a527a54eebcaf96b3/contracts/Claims.sol#L395)

Category: Code Style

Accessing an unknown chain or validator should cause a revert.