### PR TITLE
audit: APEX-451 Duplicate access to storage variable via getter getChainTokenQuantity

### DIFF
--- a/contracts/Admin.sol
+++ b/contracts/Admin.sol
@@ -50,8 +50,10 @@ contract Admin is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrade
             revert ChainIsNotRegistered(_chainId);
         }
 
-        if (claims.getChainTokenQuantity(_chainId) < _amount) {
-            revert DefundRequestTooHigh(_chainId, claims.getChainTokenQuantity(_chainId), _amount);
+        uint256 _chainTokenQuantity = claims.getChainTokenQuantity(_chainId);
+
+        if (_chainTokenQuantity < _amount) {
+            revert DefundRequestTooHigh(_chainId, _chainTokenQuantity, _amount);
         }
 
         claims.defund(_chainId, _amount, _defundAddress);

--- a/contracts/Admin.sol
+++ b/contracts/Admin.sol
@@ -46,18 +46,7 @@ contract Admin is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrade
     }
 
     function defund(uint8 _chainId, string calldata _defundAddress, uint256 _amount) external onlyFundAdmin {
-        if (!claims.isChainRegistered(_chainId)) {
-            revert ChainIsNotRegistered(_chainId);
-        }
-
-        uint256 _chainTokenQuantity = claims.getChainTokenQuantity(_chainId);
-
-        if (_chainTokenQuantity < _amount) {
-            revert DefundRequestTooHigh(_chainId, _chainTokenQuantity, _amount);
-        }
-
         claims.defund(_chainId, _amount, _defundAddress);
-
         emit ChainDefunded(_chainId, _amount);
     }
 

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -360,6 +360,16 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
     }
 
     function defund(uint8 _chainId, uint256 _amount, string calldata _defundAddress) external onlyAdminContract {
+        if (!isChainRegistered[_chainId]) {
+            revert ChainIsNotRegistered(_chainId);
+        }
+
+        uint256 _currentAmount = chainTokenQuantity[_chainId];
+
+        if (_currentAmount < _amount) {
+            revert DefundRequestTooHigh(_chainId, _currentAmount, _amount);
+        }
+
         BridgingRequestClaim memory _brc = BridgingRequestClaim({
             observedTransactionHash: defundHash,
             receivers: new Receiver[](1),
@@ -372,7 +382,7 @@ contract Claims is IBridgeStructs, Initializable, OwnableUpgradeable, UUPSUpgrad
         _brc.receivers[0].amount = _amount;
         _brc.receivers[0].destinationAddress = _defundAddress;
 
-        chainTokenQuantity[_chainId] -= _amount;
+        chainTokenQuantity[_chainId] = _currentAmount - _amount;
 
         uint256 _confirmedTxCount = getBatchingTxsCount(_chainId);
 


### PR DESCRIPTION
Reference: [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/66571fec0681e512323caa23ad321227f6b31e6a/contracts/Admin.sol#L53)

Category: Performance

The issue can be mitigated by using a local variable to store the method result