### PR TITLE
audit: APEX-463 Should use `isVoteRestricted` instead of duplicating code

### DIFF
--- a/contracts/ClaimsHelper.sol
+++ b/contracts/ClaimsHelper.sol
@@ -69,7 +69,7 @@ contract ClaimsHelper is IBridgeStructs, Initializable, OwnableUpgradeable, UUPS
         bytes32 _hash,
         uint256 _quorumCnt
     ) external onlySignedBatchesOrClaims returns (bool) {
-        if (hasVoted[_hash][_voter] || numberOfVotes[_hash] >= _quorumCnt) {
+        if (isVoteRestricted(_voter, _hash, _quorumCnt)) {
             return false;
         }
 
@@ -77,7 +77,7 @@ contract ClaimsHelper is IBridgeStructs, Initializable, OwnableUpgradeable, UUPS
         return ++numberOfVotes[_hash] >= _quorumCnt;
     }
 
-    function isVoteRestricted(address _voter, bytes32 _hash, uint256 _quorumCnt) external view returns (bool) {
+    function isVoteRestricted(address _voter, bytes32 _hash, uint256 _quorumCnt) public view returns (bool) {
         return hasVoted[_hash][_voter] || numberOfVotes[_hash] >= _quorumCnt;
     }
 


### PR DESCRIPTION
Reference: [link](https://github.com/Ethernal-Tech/apex-bridge-smartcontracts/blob/66571fec0681e512323caa23ad321227f6b31e6a/contracts/ClaimsHelper.sol#L72)

Category: Code Style 

Code duplication can be solved by using a method `isVoteRestricted`.