### PR TITLE
AD-611 AUDIT: Gas optimization improvements according to audit report

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -121,7 +121,8 @@ contract Bridge is IBridge, Utils, Initializable, OwnableUpgradeable, UUPSUpgrad
         if (!claims.isChainRegistered(_chainId)) {
             revert ChainIsNotRegistered(_chainId);
         }
-        for (uint i = 0; i < chains.length; i++) {
+        uint256 _chainsLength = chains.length;
+        for (uint i = 0; i < _chainsLength; i++) {
             if (chains[i].id == _chainId) {
                 chains[i].addressMultisig = addressMultisig;
                 chains[i].addressFeePayer = addressFeePayer;
@@ -294,8 +295,8 @@ contract Bridge is IBridge, Utils, Initializable, OwnableUpgradeable, UUPSUpgrad
         return claims.getBatchTransactions(_chainId, _batchId);
     }
 
-    function _bytes32ToBytesAssembly(bytes32 input) internal pure returns (bytes memory) {
-        bytes memory output = new bytes(32);
+    function _bytes32ToBytesAssembly(bytes32 input) internal pure returns (bytes memory output) {
+        output = new bytes(32);
 
         assembly {
             mstore(add(output, 32), input)

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -13,15 +13,15 @@ contract Validators is IBridgeStructs, Utils, Initializable, OwnableUpgradeable,
 
     // slither-disable too-many-digits
     address constant PRECOMPILE = 0x0000000000000000000000000000000000002050;
+    uint32 constant PRECOMPILE_GAS = 50000;
     address constant VALIDATOR_BLS_PRECOMPILE = 0x0000000000000000000000000000000000002060;
+    uint32 constant VALIDATOR_BLS_PRECOMPILE_GAS = 50000;
 
     // BlockchainId -> ValidatorChainData[]
     mapping(uint8 => ValidatorChainData[]) private chainData;
     // validator address index(+1) in chainData mapping
     mapping(address => uint8) private addressValidatorIndex;
 
-    uint32 constant PRECOMPILE_GAS = 50000;
-    uint32 constant VALIDATOR_BLS_PRECOMPILE_GAS = 50000;
     // max possible number of validators is 127
     uint8 public validatorsCount;
 

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -9,19 +9,19 @@ import "./Utils.sol";
 
 contract Validators is IBridgeStructs, Utils, Initializable, OwnableUpgradeable, UUPSUpgradeable {
     address private upgradeAdmin;
+    address private bridgeAddress;
 
     // slither-disable too-many-digits
     address constant PRECOMPILE = 0x0000000000000000000000000000000000002050;
-    uint32 constant PRECOMPILE_GAS = 50000;
     address constant VALIDATOR_BLS_PRECOMPILE = 0x0000000000000000000000000000000000002060;
-    uint256 constant VALIDATOR_BLS_PRECOMPILE_GAS = 50000;
-
-    address private bridgeAddress;
 
     // BlockchainId -> ValidatorChainData[]
     mapping(uint8 => ValidatorChainData[]) private chainData;
     // validator address index(+1) in chainData mapping
     mapping(address => uint8) private addressValidatorIndex;
+
+    uint32 constant PRECOMPILE_GAS = 50000;
+    uint32 constant VALIDATOR_BLS_PRECOMPILE_GAS = 50000;
     // max possible number of validators is 127
     uint8 public validatorsCount;
 
@@ -125,7 +125,7 @@ contract Validators is IBridgeStructs, Utils, Initializable, OwnableUpgradeable,
         // recreate array with n elements
         delete chainData[_chainId];
 
-        for (uint i; i < validatorsCount; i++) {
+        for (uint i; i < validatorsCnt; i++) {
             chainData[_chainId].push();
 
             ValidatorAddressChainData calldata dt = _chainDatas[i];
@@ -149,9 +149,10 @@ contract Validators is IBridgeStructs, Utils, Initializable, OwnableUpgradeable,
                 chainData[_chainId].push();
             }
         }
-
-        uint8 indx = addressValidatorIndex[_addr] - 1;
-        chainData[_chainId][indx] = _data;
+        unchecked {
+            uint8 indx = addressValidatorIndex[_addr] - 1;
+            chainData[_chainId][indx] = _data;
+        }
     }
 
     function getValidatorsChainData(uint8 _chainId) external view returns (ValidatorChainData[] memory) {


### PR DESCRIPTION
Not done:
1. We consider the current implementation of function setChainAdditionalData() a bit more gas efficient and a bit more readable compared to the suggested one
2. For updateTimeoutBlocksNumber() and updateMaxNumberOfTransactions(), we do not use uint256 since eventually we will set those values to storage that is not set as uint256
3. Gas refund for deleting confirmed transactions that have completed lifecycle. After BatchExecutedClaim and BatchExecutionFailedClaim, Oracles still use data stored in confirmedTransaction from the “old” batch
