### PR TITLE
AD-664 Optimisation: Remove the hasVoted Mapping from SignedBatches Contract

### DIFF
--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -30,6 +30,7 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     /// @dev hash -> bls bitmap
     mapping(bytes32 => uint256) private bitmap;
 
+    // Deprecated: was used for tracking votes in previous version, no longer used in current version
     mapping(bytes32 => mapping(address => bool)) public _notUsedAnymoreHasVoted;
 
     /// @notice Stores the last confirmed batch per destination chain
@@ -160,8 +161,11 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     }
 
     function hasVoted(bytes32 _hash, address _addr) external view returns (bool) {
-        uint8 _validatorIdx = validators.getValidatorIndex(_addr) - 1;
-        return bitmap[_hash] & (1 << _validatorIdx) != 0;
+        uint8 _validatorIdx = validators.getValidatorIndex(_addr);
+        if (_validatorIdx == 0) {
+            return false; // address is not a validator
+        }
+        return bitmap[_hash] & (1 << (_validatorIdx - 1)) != 0;
     }
 
     /// @notice Returns the current version of the contract

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -108,11 +108,14 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
         );
 
         uint8 _validatorIdx = validators.getValidatorIndex(_caller) - 1;
-        uint256 _validatorMask = 1 << _validatorIdx;
         uint256 _bitmapValue = bitmap[_sbHash];
+        uint256 _bitmapNewValue;
+        unchecked {
+            _bitmapNewValue = _bitmapValue | (1 << _validatorIdx);
+        }
 
         // check if caller already voted for same hash and skip if he did
-        if (_bitmapValue & _validatorMask != 0) {
+        if (_bitmapValue == _bitmapNewValue) {
             return;
         }
 
@@ -121,9 +124,7 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
 
         signatures[_sbHash].push(_signedBatch.signature);
         feeSignatures[_sbHash].push(_signedBatch.feeSignature);
-        unchecked {
-            bitmap[_sbHash] = _bitmapValue | _validatorMask;
-        }
+        bitmap[_sbHash] = _bitmapNewValue;
 
         // check if quorum reached (+1 is last vote)
         if (_numberOfVotes + 1 >= _quorumCount) {

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -30,10 +30,6 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     /// @dev hash -> bls bitmap
     mapping(bytes32 => uint256) private bitmap;
 
-    /// @notice Tracks if an address has voted for a specific batch hash
-    /// @dev hash -> user address -> true/false
-    mapping(bytes32 => mapping(address => bool)) public hasVoted;
-
     /// @notice Stores the last confirmed batch per destination chain
     /// @dev BlockchainId -> ConfirmedBatch
     mapping(uint8 => ConfirmedBatch) private lastConfirmedBatch;
@@ -108,21 +104,22 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
             )
         );
 
+        uint8 _validatorIdx = validators.getValidatorIndex(_caller) - 1;
+        uint256 _validatorMask = 1 << _validatorIdx;
+        uint256 _bitmapValue = bitmap[_sbHash];
+
         // check if caller already voted for same hash and skip if he did
-        if (hasVoted[_sbHash][_caller]) {
+        if (_bitmapValue & _validatorMask != 0) {
             return;
         }
 
         uint256 _quorumCount = validators.getQuorumNumberOfValidators();
         uint256 _numberOfVotes = signatures[_sbHash].length;
-        uint8 validatorIdx = validators.getValidatorIndex(_caller) - 1;
-
-        hasVoted[_sbHash][_caller] = true;
 
         signatures[_sbHash].push(_signedBatch.signature);
         feeSignatures[_sbHash].push(_signedBatch.feeSignature);
         unchecked {
-            bitmap[_sbHash] = bitmap[_sbHash] | (1 << validatorIdx);
+            bitmap[_sbHash] = _bitmapValue | _validatorMask;
         }
 
         // check if quorum reached (+1 is last vote)
@@ -158,6 +155,13 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
 
     function getNumberOfSignatures(bytes32 _hash) external view returns (uint256, uint256) {
         return (signatures[_hash].length, feeSignatures[_hash].length);
+    }
+
+    function hasVoted(bytes32 _hash, address _addr) external view returns (bool) {
+        uint8 _validatorIdx = validators.getValidatorIndex(_addr) - 1;
+        uint256 _validatorMask = 1 << _validatorIdx;
+        uint256 _bitmapValue = bitmap[_hash];
+        return (_bitmapValue & _validatorMask != 0);
     }
 
     /// @notice Returns the current version of the contract

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -30,9 +30,6 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     /// @dev hash -> bls bitmap
     mapping(bytes32 => uint256) private bitmap;
 
-    // Deprecated: was used for tracking votes in previous version, no longer used in current version
-    mapping(bytes32 => mapping(address => bool)) public _notUsedAnymoreHasVoted;
-
     /// @notice Stores the last confirmed batch per destination chain
     /// @dev BlockchainId -> ConfirmedBatch
     mapping(uint8 => ConfirmedBatch) private lastConfirmedBatch;

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -29,6 +29,8 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     /// @notice Maps batch hash to BLS validator bitmap.
     /// @dev hash -> bls bitmap
     mapping(bytes32 => uint256) private bitmap;
+    
+    mapping(bytes32 => mapping(address => bool)) public _notUsedAnymoreHasVoted;
 
     /// @notice Stores the last confirmed batch per destination chain
     /// @dev BlockchainId -> ConfirmedBatch

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -29,7 +29,7 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
     /// @notice Maps batch hash to BLS validator bitmap.
     /// @dev hash -> bls bitmap
     mapping(bytes32 => uint256) private bitmap;
-    
+
     mapping(bytes32 => mapping(address => bool)) public _notUsedAnymoreHasVoted;
 
     /// @notice Stores the last confirmed batch per destination chain
@@ -161,9 +161,7 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
 
     function hasVoted(bytes32 _hash, address _addr) external view returns (bool) {
         uint8 _validatorIdx = validators.getValidatorIndex(_addr) - 1;
-        uint256 _validatorMask = 1 << _validatorIdx;
-        uint256 _bitmapValue = bitmap[_hash];
-        return (_bitmapValue & _validatorMask != 0);
+        return bitmap[_hash] & (1 << _validatorIdx) != 0;
     }
 
     /// @notice Returns the current version of the contract


### PR DESCRIPTION
It is possible to use bitmap instead of hasVoted mapping