### PR TITLE
Staking delegation on smart contracts

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -289,21 +289,11 @@ contract Bridge is IBridge, Utils, Initializable, OwnableUpgradeable, UUPSUpgrad
     /// @param _destinationChain ID of the destination chain.
     /// @return _result ID of the next batch or 0 if no batch should be created.
     function getNextBatchId(uint8 _destinationChain) external view override returns (uint64 _result) {
-        if (!shouldCreateBatch(_destinationChain)) {
+        if (!shouldCreateBatch(_destinationChain) && !claims.shouldCreateStakeDelBatch(_destinationChain)) {
             return 0;
         }
 
         uint64 batchId = signedBatches.getConfirmedBatchId(_destinationChain);
-
-        return batchId + 1;
-    }
-
-    function getNextBatchIdForStakeDel(uint8 chainId) external view override returns (uint64 _result) {
-        if (!claims.shouldCreateStakeDelBatch(chainId)) {
-            return 0;
-        }
-
-        uint64 batchId = signedBatches.getConfirmedBatchId(chainId);
 
         return batchId + 1;
     }

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -51,7 +51,7 @@ contract Claims is IBridgeStructs, Utils, Initializable, OwnableUpgradeable, UUP
 
     /// @notice Mapping from chain ID and nonce to confirmed transaction.
     /// @dev BlockchainId -> nonce -> ConfirmedTransaction
-    mapping(uint8 => mapping(uint64 => ConfirmedTransaction)) public confirmedTransactions; 
+    mapping(uint8 => mapping(uint64 => ConfirmedTransaction)) public confirmedTransactions;
 
     /// @notice Mapping from chain ID to nonce of the last confirmed transaction.
     /// @dev chainId -> nonce

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -85,6 +85,8 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
             return; // skip if this is not batch we are expecting
         }
 
+       // TODO: what if contract upgrade happens before quorum is reached and some of the validators have already submitted
+       // _sbHash will be different?
         bytes32 _sbHash = keccak256(
             abi.encodePacked(
                 _signedBatch.id,
@@ -92,7 +94,8 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
                 _signedBatch.lastTxNonceId,
                 _destinationChainId,
                 _signedBatch.rawTransaction,
-                _signedBatch.isConsolidation
+                _signedBatch.isConsolidation,
+                _signedBatch.isStakeDelegation
             )
         );
 
@@ -124,7 +127,8 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
                 _votesInfo.bitmap,
                 _signedBatch.rawTransaction,
                 _sbId,
-                _signedBatch.isConsolidation
+                _signedBatch.isConsolidation,
+                _signedBatch.isStakeDelegation
             );
 
             claimsHelper.setConfirmedSignedBatchData(_signedBatch);

--- a/contracts/SignedBatches.sol
+++ b/contracts/SignedBatches.sol
@@ -85,8 +85,6 @@ contract SignedBatches is IBridgeStructs, Utils, Initializable, OwnableUpgradeab
             return; // skip if this is not batch we are expecting
         }
 
-       // TODO: what if contract upgrade happens before quorum is reached and some of the validators have already submitted
-       // _sbHash will be different?
         bytes32 _sbHash = keccak256(
             abi.encodePacked(
                 _signedBatch.id,

--- a/contracts/interfaces/IBridge.sol
+++ b/contracts/interfaces/IBridge.sol
@@ -10,8 +10,6 @@ abstract contract IBridge is IBridgeStructs {
     /// @param _claims The claims submitted by a validator.
     function submitClaims(ValidatorClaims calldata _claims) external virtual;
 
-    function delegateAddrToStakePool(uint8 chainId, string calldata stakePoolId) external virtual;
-
     /// @notice Submit a signed transaction batch for the Cardano chain.
     /// @param _signedBatch The batch of signed transactions.
     function submitSignedBatch(SignedBatch calldata _signedBatch) external virtual;
@@ -80,6 +78,14 @@ abstract contract IBridge is IBridgeStructs {
         uint8 _destinationChain
     ) external view virtual returns (ConfirmedTransaction[] memory _confirmedTransactions);
 
+    /// @notice Adds a transaction to delegate the validator address to a specific stake pool for a given chain.
+    /// @param chainId The ID of the destination chain.
+    /// @param stakePoolId The identifier of the stake pool to delegate to.
+    function delegateAddrToStakePool(uint8 chainId, string calldata stakePoolId) external virtual;
+
+    /// @notice Returns the list of stake delegation transactions that are pending batching for a given chain.
+    /// @param _chainId The ID of the chain for which to retrieve stake delegation transactions.
+    /// @return _stakeDelTransactions Array of unbatched stake delegation transactions for the given chain.
     function getStakeDelegationTransactions(
         uint8 _chainId
     ) external view virtual returns (StakeDelegationTransaction[] memory _stakeDelTransactions);

--- a/contracts/interfaces/IBridge.sol
+++ b/contracts/interfaces/IBridge.sol
@@ -73,8 +73,6 @@ abstract contract IBridge is IBridgeStructs {
     /// @return _result ID of the next batch or 0 if no batch should be created.
     function getNextBatchId(uint8 _destinationChain) external view virtual returns (uint64 _result);
 
-    function getNextBatchIdForStakeDel(uint8 chainId) external view virtual returns (uint64 _result);
-
     /// @notice Get confirmed transactions ready for batching for a specific destination chain.
     /// @param _destinationChain ID of the destination chain.
     /// @return _confirmedTransactions Array of confirmed transactions.

--- a/contracts/interfaces/IBridge.sol
+++ b/contracts/interfaces/IBridge.sol
@@ -10,6 +10,8 @@ abstract contract IBridge is IBridgeStructs {
     /// @param _claims The claims submitted by a validator.
     function submitClaims(ValidatorClaims calldata _claims) external virtual;
 
+    function delegateAddrToStakePool(uint8 chainId, string calldata stakePoolId) external virtual;
+
     /// @notice Submit a signed transaction batch for the Cardano chain.
     /// @param _signedBatch The batch of signed transactions.
     function submitSignedBatch(SignedBatch calldata _signedBatch) external virtual;
@@ -71,12 +73,18 @@ abstract contract IBridge is IBridgeStructs {
     /// @return _result ID of the next batch or 0 if no batch should be created.
     function getNextBatchId(uint8 _destinationChain) external view virtual returns (uint64 _result);
 
+    function getNextBatchIdForStakeDel(uint8 chainId) external view virtual returns (uint64 _result);
+
     /// @notice Get confirmed transactions ready for batching for a specific destination chain.
     /// @param _destinationChain ID of the destination chain.
     /// @return _confirmedTransactions Array of confirmed transactions.
     function getConfirmedTransactions(
         uint8 _destinationChain
     ) external view virtual returns (ConfirmedTransaction[] memory _confirmedTransactions);
+
+    function getStakeDelegationTransactions(
+        uint8 _chainId
+    ) external view virtual returns (StakeDelegationTransaction[] memory _stakeDelTransactions);
 
     /// @notice Get the confirmed batch for the given destination chain.
     /// @param _destinationChain ID of the destination chain.

--- a/contracts/interfaces/IBridgeStructs.sol
+++ b/contracts/interfaces/IBridgeStructs.sol
@@ -53,6 +53,7 @@ interface IBridgeStructs {
         uint8 destinationChainId;
     }
 
+    /// @notice A stake delegation transaction ready for batching.
     struct StakeDelegationTransaction {
         uint8 chainId;
         string stakePoolId;

--- a/contracts/interfaces/IBridgeStructs.sol
+++ b/contracts/interfaces/IBridgeStructs.sol
@@ -14,6 +14,7 @@ interface IBridgeStructs {
         bytes feeSignature;
         bytes rawTransaction;
         bool isConsolidation;
+        bool isStakeDelegation;
     }
 
     /// @notice Metadata for a batch that has been confirmed.
@@ -22,6 +23,7 @@ interface IBridgeStructs {
         uint64 lastTxNonceId;
         bool isConsolidation;
         uint8 status; // 0 = deleted, 1 = in progress, 2 = executed, 3 = failed
+        bool isStakeDelegation;
     }
 
     /// @notice Data for a confirmed batch that was executed on-chain.
@@ -32,6 +34,7 @@ interface IBridgeStructs {
         bytes rawTransaction;
         uint64 id;
         bool isConsolidation;
+        bool isStakeDelegation;
     }
 
     /// @notice A transaction that has been confirmed and is ready for batching.
@@ -48,6 +51,12 @@ interface IBridgeStructs {
         Receiver[] receivers;
         bytes outputIndexes;
         uint8 destinationChainId;
+    }
+
+    struct StakeDelegationTransaction {
+        uint8 chainId;
+        string stakePoolId;
+        uint64 nonce;
     }
 
     /// @notice Represents a block from the Cardano chain.

--- a/test/Admin.test.ts
+++ b/test/Admin.test.ts
@@ -3,12 +3,6 @@ import { expect } from "chai";
 import { deployBridgeFixture } from "./fixtures";
 
 describe("Admin Functions", function () {
-  beforeEach(async () => {
-    // mock isSignatureValid precompile to always return true
-    await setCode("0x0000000000000000000000000000000000002050", "0x600160005260206000F3");
-    await setCode("0x0000000000000000000000000000000000002060", "0x600160005260206000F3");
-  });
-
   describe("Chain Token Quantity", function () {
     it("Should revert if updateChainTokenQuantity is not called by fundAdmin", async function () {
       const { admin, validators } = await loadFixture(deployBridgeFixture);

--- a/test/BatchCreation.test.ts
+++ b/test/BatchCreation.test.ts
@@ -258,7 +258,7 @@ describe("Batch Creation", function () {
       // consensus
       await bridge.connect(validators[3]).submitSignedBatch(signedBatch);
 
-      expect(await claims.shouldCreateBatch(signedBatch.destinationChainId)).to.equal(false);
+      expect(await claims.shouldCreateRegularBatch(signedBatch.destinationChainId)).to.equal(false);
 
       const confBatch = await bridge.connect(validators[1]).getConfirmedBatch(signedBatch.destinationChainId);
       expect(confBatch.bitmap).to.equal(30);

--- a/test/BatchCreation.test.ts
+++ b/test/BatchCreation.test.ts
@@ -4,12 +4,6 @@ import { ethers } from "hardhat";
 import { deployBridgeFixture } from "./fixtures";
 
 describe("Batch Creation", function () {
-  beforeEach(async () => {
-    // mock isSignatureValid precompile to always return true
-    await setCode("0x0000000000000000000000000000000000002050", "0x600160005260206000F3");
-    await setCode("0x0000000000000000000000000000000000002060", "0x600160005260206000F3");
-  });
-
   async function impersonateAsContractAndMintFunds(contractAddress: string) {
     const hre = require("hardhat");
     const address = await contractAddress.toLowerCase();

--- a/test/BatchCreation.test.ts
+++ b/test/BatchCreation.test.ts
@@ -95,13 +95,14 @@ describe("Batch Creation", function () {
       const { bridge, signedBatches, validators, signedBatch } = await loadFixture(deployBridgeFixture);
 
       const encoded = ethers.solidityPacked(
-        ["uint64", "uint64", "uint64", "uint8", "bytes", "bool"],
+        ["uint64", "uint64", "uint64", "uint8", "bytes", "bool", "bool"],
         [
           signedBatch.id,
           signedBatch.firstTxNonceId,
           signedBatch.lastTxNonceId,
           signedBatch.destinationChainId,
           signedBatch.rawTransaction,
+          false,
           false,
         ]
       );
@@ -487,13 +488,14 @@ describe("Batch Creation", function () {
       await bridge.connect(validators[2]).submitSignedBatch(signedBatch);
 
       const encoded = ethers.solidityPacked(
-        ["uint64", "uint64", "uint64", "uint8", "bytes", "bool"],
+        ["uint64", "uint64", "uint64", "uint8", "bytes", "bool", "bool"],
         [
           signedBatch.id,
           signedBatch.firstTxNonceId,
           signedBatch.lastTxNonceId,
           signedBatch.destinationChainId,
           signedBatch.rawTransaction,
+          false,
           false,
         ]
       );

--- a/test/ClaimsHelper.test.ts
+++ b/test/ClaimsHelper.test.ts
@@ -13,7 +13,7 @@ describe("ClaimsHelper Contract", function () {
       );
     });
 
-    it("Should revert if ClaimsHelper SC resetCurrentBatchBlock is not called by SignedBatches SC or Claims SC", async function () {
+    it("Should revert if ClaimsHelper SC setConfirmedSignedBatchData is not called by SignedBatches SC or Claims SC", async function () {
       const { bridge, claimsHelper, owner, signedBatch } = await loadFixture(deployBridgeFixture);
 
       await expect(claimsHelper.connect(owner).setConfirmedSignedBatchData(signedBatch)).to.be.revertedWithCustomError(
@@ -34,6 +34,34 @@ describe("ClaimsHelper Contract", function () {
             1
           )
       ).to.be.revertedWithCustomError(bridge, "NotSignedBatchesOrClaims");
+    });
+  });
+  describe("Submit new Stake Delegation Transaction", function () {
+    it("Should revert if ClaimsHelper SC addStakeDelegationTransactions is not called by Claims SC", async function () {
+      const { bridge, claimsHelper, owner, chain1 } = await loadFixture(deployBridgeFixture);
+
+      await expect(claimsHelper.connect(owner).addStakeDelegationTransactions(chain1.id, "stakePoolId")).to.be.revertedWithCustomError(
+        bridge,
+        "NotClaims"
+      );
+    });
+
+    it("Should revert if ClaimsHelper SC setLastBatchedStakeDelTxNonce is not called by Claims SC", async function () {
+      const { bridge, claimsHelper, owner, chain1 } = await loadFixture(deployBridgeFixture);
+
+      await expect(claimsHelper.connect(owner).setLastBatchedStakeDelTxNonce(chain1.id, 1)).to.be.revertedWithCustomError(
+        bridge,
+        "NotClaims"
+      );
+    });
+
+    it("Should revert if ClaimsHelper SC retryStakeDelTxs is not called by Claims SC", async function () {
+      const { bridge, claimsHelper, owner, chain1 } = await loadFixture(deployBridgeFixture);
+
+      await expect(claimsHelper.connect(owner).retryStakeDelTxs(chain1.id, 1, 2)).to.be.revertedWithCustomError(
+        bridge,
+        "NotClaims"
+      );
     });
   });
 });

--- a/test/StakeDelegation.test.ts
+++ b/test/StakeDelegation.test.ts
@@ -1,0 +1,101 @@
+import { loadFixture, setCode, reset } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deployBridgeFixture } from "./fixtures";
+
+describe("Stake Delegation", function () {
+    
+    const stakePoolIds = ["stakePoolId", "stakePoolId1", "stakePoolId2"];
+
+    async function registerChainAndDelegate(bridge, owner, chain, validatorData, count = 2) {
+        await bridge.connect(owner).registerChain(chain, 10000, 10000, validatorData);
+        for (let i = 0; i < count; i++) {
+        await bridge.connect(owner).delegateAddrToStakePool(chain.id, stakePoolIds[i]);
+        }
+    }
+
+    it("Should revert if delegation is not sent by owner", async function () {
+      const { bridge, chain1, validators } = await loadFixture(deployBridgeFixture);
+
+      await expect(bridge.connect(validators[0]).delegateAddrToStakePool(chain1.id, stakePoolIds[0]))
+        .to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("Should revert if chain is not registered", async () => {
+        const { bridge, owner, chain1 } = await loadFixture(deployBridgeFixture);
+
+        await expect(bridge.connect(owner).delegateAddrToStakePool(chain1.id, stakePoolIds[0]))
+        .to.be.revertedWithCustomError(bridge, "ChainIsNotRegistered");
+    });
+
+    it("Should increase stake delegation nonce when delegation is added", async function () {
+        const { bridge, claimsHelper, owner, chain1, chain2, validatorAddressChainData } =
+        await loadFixture(deployBridgeFixture);
+
+        await bridge.connect(owner).registerChain(chain1, 10000, 10000, validatorAddressChainData);
+
+        expect(await claimsHelper.lastStakeDelegationTxNonce(chain1.id)).to.equal(0);
+
+        await bridge.connect(owner).delegateAddrToStakePool(chain1.id, stakePoolIds[0]);
+
+        expect(await claimsHelper.lastStakeDelegationTxNonce(chain1.id)).to.equal(1);
+    });
+
+    it("Should store new stakeDelegationTx correctly", async function () {
+        const { bridge, claimsHelper, owner, chain1, validatorAddressChainData } =
+        await loadFixture(deployBridgeFixture);
+
+        await registerChainAndDelegate(bridge, owner, chain1, validatorAddressChainData, 1);
+        const nonce = await claimsHelper.lastStakeDelegationTxNonce(chain1.id);
+
+        const tx = await claimsHelper.stakeDelegationTransactions(chain1.id, nonce);
+        expect(tx.chainId).to.equal(chain1.id);
+        expect(tx.stakePoolId).to.equal(stakePoolIds[0]);
+        expect(tx.nonce).to.equal(nonce);
+    });
+
+    it("Should not create batch if chain is not registered", async function () {
+        const { claims, chain1 } = await loadFixture(deployBridgeFixture);
+        expect(await claims.shouldCreateStakeDelBatch(chain1.id)).to.be.false;
+    });
+
+    it("Should create batch after adding stake delegation txs", async function () {
+        const { bridge, claims, owner, chain1, validatorAddressChainData } =
+            await loadFixture(deployBridgeFixture);
+
+        await registerChainAndDelegate(bridge, owner, chain1, validatorAddressChainData, 2);        
+        expect(await claims.shouldCreateStakeDelBatch(chain1.id)).to.be.true;
+    });
+
+    it("Should return correct stake delegation txs for new batch", async function () {
+        const { bridge, owner, chain1, validatorAddressChainData } =
+            await loadFixture(deployBridgeFixture);
+
+        await registerChainAndDelegate(bridge, owner, chain1, validatorAddressChainData, 3);
+        const stakeDelTxs = await bridge.getStakeDelegationTransactions(chain1.id);
+
+        const maxNumberOfTransactions = 2;
+        expect(stakeDelTxs.length).to.equal(maxNumberOfTransactions);
+
+        expect(stakeDelTxs[0].chainId).to.equal(chain1.id);
+        expect(stakeDelTxs[0].stakePoolId).to.equal(stakePoolIds[0]);
+        expect(stakeDelTxs[0].nonce).to.equal(1);
+
+        expect(stakeDelTxs[1].chainId).to.equal(chain1.id);
+        expect(stakeDelTxs[1].stakePoolId).to.equal(stakePoolIds[1]);
+        expect(stakeDelTxs[1].nonce).to.equal(2);
+    });
+
+    it("Should not create batch when execution is in progress", async function () {
+        const { bridge, claims, owner, validators, signedBatchStakeDel, chain1, validatorAddressChainData } =
+            await loadFixture(deployBridgeFixture);
+
+        await registerChainAndDelegate(bridge, owner, chain1, validatorAddressChainData, 2);
+
+        for (const v of validators.slice(0, 4)) {
+            await bridge.connect(v).submitSignedBatch(signedBatchStakeDel);
+        }
+
+        expect(await claims.shouldCreateStakeDelBatch(chain1.id)).to.be.false;
+    });
+});

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -430,6 +430,7 @@ export async function deployBridgeFixture() {
     rawTransaction: "0x7465737400000000000000000000000000000000000000000000000000000000",
     feeSignature: "0x746573740000000000000000000000000000000000000000000000000000000F",
     isConsolidation: false,
+    isStakeDelegation: false,
   };
 
   const signedBatchConsolidation = {
@@ -441,6 +442,7 @@ export async function deployBridgeFixture() {
     firstTxNonceId: 0,
     lastTxNonceId: 0,
     isConsolidation: true,
+    isStakeDelegation: false,
   };
 
   const signedBatchDefund = {
@@ -452,6 +454,7 @@ export async function deployBridgeFixture() {
     feeSignature: "0x746573740000000000000000000000000000000000000000000000000000000F",
     rawTransaction: "0x7465737400000000000000000000000000000000000000000000000000000000",
     isConsolidation: false,
+    isStakeDelegation: false,
   };
 
   const cardanoBlocks = [

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,7 +1,13 @@
 import { ethers } from "hardhat";
 import { Bridge, Claims, ClaimsHelper, SignedBatches, Slots, Validators, Admin } from "../typechain-types";
+import { setCode } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 export async function deployBridgeFixture() {
+  const PRECOMPILE_MOCK = "0x600160005260206000F3"; // returns true for isSignatureValid
+
+  await setCode("0x0000000000000000000000000000000000002050", PRECOMPILE_MOCK);
+  await setCode("0x0000000000000000000000000000000000002060", PRECOMPILE_MOCK);
+
   // Contracts are deployed using the first signer/account by default
   const [owner, validator1, validator2, validator3, validator4, validator5, validator6] = await ethers.getSigners();
   const validators = [validator1, validator2, validator3, validator4, validator5];
@@ -457,6 +463,18 @@ export async function deployBridgeFixture() {
     isStakeDelegation: false,
   };
 
+  const signedBatchStakeDel = {
+    id: 1,
+    firstTxNonceId: 1,
+    lastTxNonceId: 2,
+    destinationChainId: 1,
+    signature: "0x746573740000000000000000000000000000000000000000000000000000000A",
+    feeSignature: "0x746573740000000000000000000000000000000000000000000000000000000F",
+    rawTransaction: "0x7465737400000000000000000000000000000000000000000000000000000000",
+    isConsolidation: false,
+    isStakeDelegation: true,
+  };
+
   const cardanoBlocks = [
     {
       blockSlot: 1,
@@ -519,6 +537,7 @@ export async function deployBridgeFixture() {
     signedBatch,
     signedBatchConsolidation,
     signedBatchDefund,
+    signedBatchStakeDel,
     validatorAddressChainData,
     validatorCardanoData,
     validators,


### PR DESCRIPTION
`Bridge Admin` can request delegation of the multisig bridge address to a specified stake pool.

`Batch` structs must include a new flag `isStakingDelegation` to distinguish delegation-related claims from standard batch operations. If `isStakingDelegation` is true, handle the batch as a `Staking Delegation` batch; otherwise, process it as a regular batch.