### PR TITLE
getBatchStatusAndType method

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -386,6 +386,18 @@ contract Bridge is IBridge, Utils, Initializable, OwnableUpgradeable, UUPSUpgrad
         return claims.getBatchStatusAndTransactions(_chainId, _batchId);
     }
 
+    /// @notice Get status and type for a specific batch for a given chain.
+    /// @param _chainId ID of the chain.
+    /// @param _batchId ID of the batch.
+    /// @return _status Status of the batch.
+    /// @return _type Type of the batch.
+    function getBatchStatusAndType(
+        uint8 _chainId,
+        uint64 _batchId
+    ) external view override returns (uint8 _status, uint8 _type) {
+        return claims.getBatchStatusAndType(_chainId, _batchId);
+    }
+
     /// @notice Check if a new validator set is pending.
     /// @return _pending True if a new validator set is pending, false otherwise.
     function isNewValidatorSetPending() external view override returns (bool _pending) {
@@ -423,7 +435,7 @@ contract Bridge is IBridge, Utils, Initializable, OwnableUpgradeable, UUPSUpgrad
     /// @notice Returns the current version of the contract
     /// @return A semantic version string
     function version() public pure returns (string memory) {
-        return "1.1.1";
+        return "1.1.2";
     }
 
     modifier onlyValidator() {

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -783,6 +783,24 @@ contract Claims is IBridgeStructs, Utils, Initializable, OwnableUpgradeable, UUP
         return (_status, _txHashes);
     }
 
+    /// @notice Retrieves status and type for a specific batch on a given chain.
+    /// @dev This function returns status and type for a batch identified by its batch ID.
+    /// @param _chainId The ID of the chain on which the batch exists.
+    /// @param _batchId The ID of the batch to retrieve transactions for.
+    /// @return _status Status code indicating batch execution status.
+    /// @return _type Batch type.
+    function getBatchStatusAndType(
+        uint8 _chainId,
+        uint64 _batchId
+    ) external view returns (uint8 _status, uint8 _type) {
+        ConfirmedSignedBatchData memory _confirmedSignedBatch = claimsHelper.getConfirmedSignedBatchData(
+            _chainId,
+            _batchId
+        );
+
+        return (_confirmedSignedBatch.status, _confirmedSignedBatch.batchType);
+    }
+
     /// @notice Retrieves a status for a specific batch on a given chain.
     /// @param _chainId The ID of the chain on which the batch exists.
     /// @param _batchId The ID of the batch to retrieve transactions for.
@@ -820,7 +838,7 @@ contract Claims is IBridgeStructs, Utils, Initializable, OwnableUpgradeable, UUP
     /// @notice Returns the current version of the contract
     /// @return A semantic version string
     function version() public pure returns (string memory) {
-        return "1.1.0";
+        return "1.1.1";
     }
 
     modifier onlyBridge() {

--- a/contracts/interfaces/IBridge.sol
+++ b/contracts/interfaces/IBridge.sol
@@ -116,6 +116,16 @@ abstract contract IBridge is IBridgeStructs {
         uint64 _batchId
     ) external virtual returns (uint8 _status, TxDataInfo[] memory _txs);
 
+    /// @notice Get status and type for a specific batch for a given chain.
+    /// @param _chainId ID of the chain.
+    /// @param _batchId ID of the batch.
+    /// @return _status Status of the batch.
+    /// @return _type Type of the batch.
+    function getBatchStatusAndType(
+        uint8 _chainId,
+        uint64 _batchId
+    ) external virtual returns (uint8 _status, uint8 _type);
+
     /// @notice Notifies the bridge that new validator set has been implemented on Blade.
     function validatorSetUpdated() external virtual;
 

--- a/test/Claims.test.ts
+++ b/test/Claims.test.ts
@@ -794,6 +794,22 @@ describe("Claims Contract", function () {
       expect(txs).to.deep.equal([]);
       expect(status).to.equal(1);
     });
+
+    it("getBatchStatusAndType should return status and type from batch", async function () {
+      await bridge.connect(validators[0]).submitClaims(validatorClaimsBRC);
+      await bridge.connect(validators[1]).submitClaims(validatorClaimsBRC);
+      await bridge.connect(validators[2]).submitClaims(validatorClaimsBRC);
+      await bridge.connect(validators[3]).submitClaims(validatorClaimsBRC);
+
+      await bridge.connect(validators[0]).submitSignedBatch(signedBatch);
+      await bridge.connect(validators[1]).submitSignedBatch(signedBatch);
+      await bridge.connect(validators[2]).submitSignedBatch(signedBatch);
+      await bridge.connect(validators[3]).submitSignedBatch(signedBatch);
+
+      const [status, type] = await claims.getBatchStatusAndType(signedBatch.destinationChainId, signedBatch.id);
+      expect(status).to.equal(1);
+      expect(type).to.equal(0);
+    });
   });
 
   let bridge: any;


### PR DESCRIPTION
Last batch type needed in Nexus batcher during VSC should be retrieved from bridge SC. Otherwise there is a minor possibility if multiple apex-bridge processes restart after VS batch confirmation and prior VSF batch confirmation that last batch type, currently cached within Nexus batcher, is cleared during restart and VSF batch will never be sent. Hence a new method getBatchStatusAndType has been introduced to Brudge SC.